### PR TITLE
[update] test

### DIFF
--- a/src/lib/sync-articles-from-qiita.test.ts
+++ b/src/lib/sync-articles-from-qiita.test.ts
@@ -6,14 +6,14 @@ import { config } from "./config";
 jest.mock("./config");
 const mockConfig = jest.mocked(config);
 
-describe("syncArticlesFromQiita", () => {
-  const qiitaApi = {
-    authenticatedUserItems: () => {},
-  } as unknown as QiitaApi;
-  const fileSystemRepo = {
-    saveItems: () => {},
-  } as unknown as FileSystemRepo;
+const qiitaApi = {
+  authenticatedUserItems: jest.fn(),
+} as unknown as QiitaApi;
+const fileSystemRepo = {
+  saveItems: jest.fn(),
+} as unknown as FileSystemRepo;
 
+describe("syncArticlesFromQiita", () => {
   const mockAuthenticatedUserItems = jest.spyOn(
     qiitaApi,
     "authenticatedUserItems",
@@ -91,7 +91,7 @@ describe("syncArticlesFromQiita", () => {
     };
 
     describe("when forceUpdate is true", () => {
-      it("called saveItems without forceUpdate", async () => {
+      it("called saveItems with forceUpdate", async () => {
         await expectSaveItemsToBeCalledWithForceUpdate(true);
       });
     });


### PR DESCRIPTION
This pull request includes changes to the test file `src/lib/sync-articles-from-qiita.test.ts` to improve the mocking of dependencies and correct a test description. The most important changes are:

Improvements to mocking:

* Changed `authenticatedUserItems` and `saveItems` to use `jest.fn()` for better test isolation and mocking.

Correction of test description:

* Corrected the test description to indicate that `saveItems` is called with `forceUpdate` set to true.